### PR TITLE
Assume correct contract for entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ module.exports = fromEntries
 
 function fromEntries (iterable) {
   return [...iterable]
-    .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
+    .reduce((obj, { 0: key, 1: val }) => Object.assign(obj, { [key]: val }), {})
 }


### PR DESCRIPTION
Hey, quick fix quoting the official polyfill: https://github.com/tc39/proposal-object-from-entries/blob/master/polyfill.js#L9-L10 : 

```
// Consistency with Map: contract is that entry has "0" and "1" keys, not
// that it is an array or iterable.
```