### PR TITLE
Add test for generators

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -21,3 +21,13 @@ test('works on map-like objects like URLSearchParams', t => {
   t.deepEqual(obj, { foo: 'bar', baz: 'qux' })
   t.end()
 })
+
+test('works on generators', t => {
+  const obj = fromEntries((function * generator () {
+    yield ['a', 1]
+    yield ['b', 2]
+    yield ['c', 3]
+  })())
+  t.deepEqual(obj, { a: 1, b: 2, c: 3 })
+  t.end()
+})


### PR DESCRIPTION
The original specification doesn't mention generators and such iterable objects, so I decided to specific tests for generators since they're pretty much a thing in 2020 since redux-saga became popular.