### PR TITLE
use same Types as TypeScript does for Object.fromEntries

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-declare function fromEntries<Key extends string | number | Symbol, Value>(iterable: Array<[Key, Value]>): {
-    [key: Key]: Value;
-};
+declare function fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T };
 
 export = fromEntries;


### PR DESCRIPTION
Hey Feross 👋🏼 

This resolves https://github.com/octokit/oauth-app.js/pull/137/checks?check_run_id=1290708485

compare https://github.com/microsoft/TypeScript/blob/97083ea6a289765024bc2b119a3f3be72dcc464d/lib/lib.es2019.object.d.ts#L28